### PR TITLE
Fix AttributeError on current ComfyUI: defensive getattr in compat patch

### DIFF
--- a/iamccs_comfy_compat.py
+++ b/iamccs_comfy_compat.py
@@ -16,8 +16,12 @@ def apply_iamccs_comfy_compat_patches():
         return
 
     if not getattr(loaded_model_cls, "_iamccs_tts_audio_suite_compat", False):
-        original_model_mmap_residency = loaded_model_cls.model_mmap_residency
-        original_is_dead = loaded_model_cls.is_dead
+        # Newer ComfyUI versions have dropped these methods from LoadedModel.
+        # Grab them defensively so the patch still installs the safe shims
+        # (which already cope with the underlying method being absent).
+        original_model_mmap_residency = getattr(
+            loaded_model_cls, "model_mmap_residency", None)
+        original_is_dead = getattr(loaded_model_cls, "is_dead", None)
 
         def safe_model_mmap_residency(self, free=False):
             model = getattr(self, "model", None)


### PR DESCRIPTION
## Summary

`apply_iamccs_comfy_compat_patches()` currently fails at import time on recent ComfyUI builds:

```
File "iamccs_comfy_compat.py", line 19, in apply_iamccs_comfy_compat_patches
    original_model_mmap_residency = loaded_model_cls.model_mmap_residency
AttributeError: type object 'LoadedModel' has no attribute 'model_mmap_residency'
```

The patch's intent is to preserve the original `LoadedModel.model_mmap_residency` / `LoadedModel.is_dead` references before installing safer wrappers. On current ComfyUI those methods no longer exist on `LoadedModel`, so the direct attribute lookup raises `AttributeError` and the whole pack fails to load.

## Fix

Fetch the originals with `getattr(..., None)`. The safe wrappers already cope with the underlying method being absent:
- `safe_model_mmap_residency` falls back to `(0, 0)` when the model has no `model_mmap_residency`.
- `safe_is_dead` returns `False` when there's no callable `real_model` ref.

So once the references are guarded, the patch installs cleanly on both old and new ComfyUI.

## Test plan

- [x] On a ComfyUI build where `LoadedModel.model_mmap_residency` is missing: pack imports without error and the safe shims install.
- [x] No change in behavior on older ComfyUI builds that still have the attributes (the same `getattr` returns the original method, which the patch then ignores anyway — the safe wrappers handle both).